### PR TITLE
Include path needs to be modified when libfmsynth is built using the makefile.

### DIFF
--- a/fmsynth/Makefile
+++ b/fmsynth/Makefile
@@ -7,6 +7,7 @@ include ../config_post.mk
 LDFLAGS+=-lfmsynth
 FMSYNTH_LIB := libfmsynth/libfmsynth.a
 ifeq ($(wilcard ${FMSYNTH_LIB}), )
+INC += -Ilibfmsynth/include
 LDFLAGS += -L$(shell dirname ${FMSYNTH_LIB})
 endif
 


### PR DESCRIPTION
@fennecdjay  I tried building fmsynth using the makefile to pull the library from git, and I found this issue.

I wanted to do a PR here instead of just checking it in because I thought you should check it. I tried making a new branch in Gwion/gwion-plug to check my code into, but apparently even as a maintainer I don't get to make a new branch. 