### PR TITLE
Rewritten TermColor plugin

### DIFF
--- a/TermColor/termcolor.c
+++ b/TermColor/termcolor.c
@@ -10,30 +10,30 @@
 #include "import.h"
 #include "gack.h"
 
-static GACK(termcolor_gack) {
-  char static_str[1024];
-  const M_Object obj = *(M_Object *)VALUE;
-  const size_t sz = strlen(STRING(obj)) * 2;
-  const bool not_too_big = sz <= 1024;
-  char *const buf = not_too_big ?
-    static_str : mp_malloc2(shred->info->mp, sz);
-  const m_str str = STRING(obj);
-  const enum term_color_error_t err = tcol_snprintf(buf, sz, str);
-  INTERP_PRINTF("%s", err == TermColorErrorNone ? buf : str);
-  if(!not_too_big)
-    mp_free2(shred->info->mp, sz, buf);
+// Define static function `TermColor`.
+static SFUN(TermColor) {
+  const M_Object obj = *(M_Object *)MEM(0);  // Fetch first argument.
+  m_str str = STRING(obj);  // Access string data.
+
+  size_t sz = strlen(STRING(obj)) * 4;  // Grow by factor of 4x
+  char* buf = mp_malloc2(shred->info->mp, sz);  // Allocate memory in pool.
+
+  // Hand the string to tcol, it will put the result in `buf`.
+  enum term_color_error_t err = tcol_snprintf(buf, sz, str);
+
+  // Set the return value to the new string (the string constructor implicitly copies buf).
+  *(M_Object*)RETURN = new_string(shred->info->vm->gwion, buf);
+
+  // Free the buffer from the memory pool.
+  mp_free2(shred->info->mp, sz, buf);
 }
 
 GWION_IMPORT(TermColor) {
-
-  DECL_OB(const Type, t_termcolor, = gwi_class_ini(gwi, "TermColor", "string"));
-  SET_FLAG(t_termcolor, final | ae_flag_abstract);
-  gwi_gack(gwi, t_termcolor, termcolor_gack);
-  GWI_BB(gwi_class_end(gwi))
-
-  GWI_BB(gwi_oper_ini(gwi, "string", "TermColor", "TermColor"));
-  GWI_BB(gwi_oper_end(gwi, "@implicit", NoOp));
-  GWI_BB(gwi_oper_end(gwi, "$", NoOp));
+  // Declare function `TermColor` that accepts a string argument and returns a
+  // a new formatted string.
+  GWI_BB(gwi_func_ini(gwi, "string", "TermColor"));
+  GWI_BB(gwi_func_arg(gwi, "string", "str"));
+  GWI_BB(gwi_func_end(gwi, TermColor, ae_flag_none));
 
   return GW_OK;
 }


### PR DESCRIPTION
Rewrote the TermColor plugin to be more general instead of _only_
working with gack. You can now pass in a string argument and receive
a new formatted string as output which lets you use pretty colours
for writing to stdout manually etc.

We should probably find the exact size to use for the new string
rather than assuming a factor 4x increase but this works for now.